### PR TITLE
Avoid UnsupportedOperationException: This iterator does not support removal

### DIFF
--- a/src/main/java/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.java
+++ b/src/main/java/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.java
@@ -2,7 +2,6 @@ package org.checkerframework.gradle.plugin;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 import java.util.List;
@@ -13,7 +12,7 @@ import java.util.List;
 public class CheckerFrameworkPlugin implements Plugin<Project> {
 
     public void apply(final Project project) {
-        CheckerFrameworkPluginExtension extension =
+        final CheckerFrameworkPluginExtension extension =
                 project.getExtensions().create("checkerframework", CheckerFrameworkPluginExtension.class, project);
 
         applyToTasks(project, extension);
@@ -28,14 +27,14 @@ public class CheckerFrameworkPlugin implements Plugin<Project> {
      * @param extension the extension to apply the CF with
      */
     private void applyToTasks(final Project project, final CheckerFrameworkPluginExtension extension) {
-        List<String> taskNames = extension.tasks.getOrNull();
-        TaskCollection<JavaCompile> tasks = project.getTasks().withType(JavaCompile.class);
-
-        if (taskNames != null) {
-            tasks.removeIf(task -> !taskNames.contains(task.getName()));
+        final List<String> taskNameList = extension.tasks.get();
+        if (taskNameList.isEmpty()) {
+            project.getTasks().withType(JavaCompile.class).configureEach(task -> extension.applyTo(task));
         }
-
-        tasks.configureEach(task -> extension.applyTo(task));
+        else {
+            for (final String taskName : taskNameList) {
+                extension.applyTo((JavaCompile) project.getTasks().getByName(taskName));
+            }
+        }
     }
 }
-


### PR DESCRIPTION
Avoid `UnsupportedOperationException: This iterator does not support removal`

If `Task`s have been added in build script via `checkerframework.addTask()`, not longer iterate over `JavaCompile`s to remove other `Task`s, just get all `Task`s with the added names.

If name points to no `Task`, or to `Task` of wrong type, will now throw a `ClassCastException`, which alerts user about bad task names.

Improved performance.

Resolves kelloggm/checkerframework-gradle-plugin#2