### PR TITLE
Fix instructions for using a specific version of the Checker Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ add text like the following to `build.gradle`, after `apply plugin: 'org.checker
 
 ```groovy
 dependencies {
-  checkerFramework 'org.checkerframework:checker-qual:2.8.0'
+  compile 'org.checkerframework:checker-qual:2.8.0'
   checkerFramework 'org.checkerframework:checker:2.8.0'
-  checkerFramework 'org.checkerframework:jdk8:2.8.0'
+  checkerFrameworkAnnotatedJDK 'org.checkerframework:jdk8:2.8.0'
 }
 ```
 
@@ -89,9 +89,9 @@ You can also use a locally-built version of the Checker Framework:
 ```groovy
 def cfHome = String.valueOf(System.getenv("CHECKERFRAMEWORK"))
 dependencies {
-  checkerFramework files(cfHome + "/checker/dist/checker.jar")
+  compile files(cfHome + "/checker/dist/checker.jar")
   checkerFramework files(cfHome + "/checker/dist/checker-qual.jar")
-  checkerFramework files(cfHome + "/checker/dist/jdk8.jar")
+  checkerFrameworkAnnotatedJDK files(cfHome + "/checker/dist/jdk8.jar")
 }
 ```
 


### PR DESCRIPTION
The documentation seems to give incorrect dependency group names.