### PR TITLE
Basic lombok support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.4'
+    id 'org.checkerframework' version '0.3.5'
 }
 
 apply plugin: 'org.checkerframework'
@@ -134,7 +134,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.4' apply false
+  id 'org.checkerframework' version '0.3.5' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -180,6 +180,12 @@ if ("true".equals(project.ext.useCheckerFramework)) {
 }
 ```
 
+## Lombok compatibility
+
+This plugin automatically interacts with
+the [Lombok Gradle Plugin](https://plugins.gradle.org/plugin/io.freefair.lombok)
+to delombok your source code before it is passed to the Checker Framework
+for typechecking. This plugin does not support any other use of Lombok.
 
 ## Using a locally-built plugin
 
@@ -200,7 +206,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.4-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.5-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     jcenter()
     google()
 
-    // the gradle plugin portal, so that we can depend on other plugins
+    // The gradle plugin portal, so that we can depend on other plugins.
     maven {
         url "https://plugins.gradle.org/m2/"
     }
@@ -24,7 +24,7 @@ targetCompatibility = 1.8
 dependencies {
     implementation localGroovy()
 
-    // Lombok Gradle plugin, so that we can delombok sources if lombok would be applied
+    // The Lombok Gradle plugin, so that we can delombok sources if lombok would be applied.
     implementation 'io.freefair.gradle:lombok-plugin:3.7.5'
 
     testImplementation deps.android.tools.build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ plugins {
 repositories {
     jcenter()
     google()
+
+    // the gradle plugin portal, so that we can depend on other plugins
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
 }
 
 apply from: 'gradle/dependencies.gradle'
@@ -19,12 +24,15 @@ targetCompatibility = 1.8
 dependencies {
     implementation localGroovy()
 
+    // Lombok Gradle plugin, so that we can delombok sources if lombok would be applied
+    implementation 'io.freefair.gradle:lombok-plugin:3.7.5'
+
     testImplementation deps.android.tools.build.gradle
     testImplementation deps.spock, { exclude module: 'groovy-all' } // Use localGroovy()
 }
 
 group 'org.checkerframework'
-version '0.3.4'
+version '0.3.5'
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
This PR adds support for basic interaction between Lombok and the Checker Framework's gradle plugins.

The strategy is to delombok the code before it is passed to the compiler. Some modifications are also made to the lombok configuration to ensure that `@lombok.Generated` annotations are present, so that lombok'd code can be automatically detected by checkers.

Tested on a simple Gradle Java project that uses lombok, with the typesafe builder checker to ensure that an error is issued that ought to be. I didn't automate the test, but might in a future PR.

This PR also likely will not work with Android projects, which I will also support in a future release.