### PR TITLE
Fix an issue with the Lombok support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.5'
+    id 'org.checkerframework' version '0.3.9'
 }
 
 apply plugin: 'org.checkerframework'
@@ -134,7 +134,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.5' apply false
+  id 'org.checkerframework' version '0.3.9' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -206,7 +206,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.5-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.9-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.5'
+version '0.3.9'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -48,6 +48,11 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
 
     project.getPlugins().withType(io.freefair.gradle.plugins.lombok.LombokPlugin.class, new Action<LombokPlugin>() {
       void execute(LombokPlugin lombokPlugin) {
+
+        // Ensure that the lombok config is set to emit @Generated annotations
+        lombokPlugin.configureForJacoco()
+        lombokPlugin.generateLombokConfig.get().generateLombokConfig()
+
         project.gradle.projectsEvaluated {
 
           def delombokTasks = project.getTasks().findAll { task ->


### PR DESCRIPTION
In #17, I added basic support for lombok. Unfortunately, I left out an important step: generate a lombok config file that tells lombok to place `@Generated` annotations. I had thought that the fix to the formatting of the delombok request would be sufficient (and it was in my tests) - but that only worked because the appropriate `lombok.config` files were already in place thanks to my earlier testing, and weren't being re-generated.

This change re-adds the call to the Jacoco support in the Lombok plugin (conveniently, Jacoco also requires `@Generated` annotations to work correctly with Lombok, so they already had a convenient method for me to call). Then, it forces the `lombok.config` file to be re-generated, so that the change takes effect.

Tested on a fresh project with no `lombok.config` files, and then inspecting the delombok'd code by hand.