### PR TITLE
Avoid NPE when there are both lombok tasks and other non-Java compile tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.15'
+    id 'org.checkerframework' version '0.3.16'
 }
 
 apply plugin: 'org.checkerframework'
@@ -145,7 +145,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.15' apply false
+  id 'org.checkerframework' version '0.3.16' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -230,7 +230,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.15-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.16-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.15'
+version '0.3.16'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -1,5 +1,7 @@
 package org.checkerframework.gradle.plugin
 
+import org.gradle.api.Task
+
 import java.util.jar.JarFile
 
 import org.gradle.api.Action
@@ -58,7 +60,7 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
         project.gradle.projectsEvaluated {
 
           def delombokTasks = project.getTasks().findAll { task ->
-            task.name.startsWith("delombok")
+            task.name.contains("delombok")
           }
 
           if (delombokTasks.size() != 0) {
@@ -71,7 +73,8 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
 
               // find the right delombok task
               def delombokTask = delombokTasks.find { task ->
-                if (task.name.equals("delombok")) {
+
+                if (task.name.endsWith("delombok")) {
                   // special-case the main compile task because its just named "compileJava"
                   // without anything else
                   compile.name.equals("compileJava")
@@ -81,12 +84,16 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
                 }
               }
 
-              // the lombok plugin's default formatting is pretty-printing, without the @Generated annotations
-              // that we need to recognize lombok'd code
-              delombokTask.format.put('generated', 'generate')
+              // delombokTask can still be null; for example, if the code contains a compileScala task
+              if (delombokTask != null) {
 
-              compile.dependsOn(delombokTask)
-              compile.setSource(delombokTask.target.getAsFile().get())
+                // the lombok plugin's default formatting is pretty-printing, without the @Generated annotations
+                // that we need to recognize lombok'd code
+                delombokTask.format.put('generated', 'generate')
+
+                compile.dependsOn(delombokTask)
+                compile.setSource(delombokTask.target.getAsFile().get())
+              }
             }
           }
         }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -1,7 +1,5 @@
 package org.checkerframework.gradle.plugin
 
-import org.gradle.api.Task
-
 import java.util.jar.JarFile
 
 import org.gradle.api.Action


### PR DESCRIPTION
When no Java compilation task is matched to a delombok task, do not throw a null pointer exception, since there are legitimate reasons to have non-Java compile tasks.

This came up in a case study of the Lombok builder checking capability of the Object Construction Checker. I confirmed that the fix works on that case study.

No 0.3.16 release has been made. When this is merged, whoever merges it should make that release.

I also modified the check for what is a delombok task, because the delombok tasks of subprojects are prefixed with the subproject name. The previous version of the plugin also did not support Lombok in subprojects.