### PR TITLE
Add better subproject support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ By default, checkers are run on all subprojects of the project to which the plug
 is applied.
 
 In most projects with subprojects, the top-level project is not a Java
-project.  You should not configure such a non-Java block.  Instead, move
+project.  You should not configure such a non-Java project.  Instead, move
 all Checker Framework configuration (the `checkerFramework` block and any
 `dependencies`) into a `subprojects` block. For example:
 
@@ -150,7 +150,7 @@ subprojects { subproject ->
 }
 ```
 
-To not apply the plugin only to subprojects, set the `applyToSubprojects`
+To not apply the plugin to all subprojects, set the `applyToSubprojects`
 flag to `false`:
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.16'
+    id 'org.checkerframework' version '0.3.17'
 }
 
 apply plugin: 'org.checkerframework'
@@ -127,6 +127,36 @@ checkerFramework {
 }
 ```
 
+### Multi-project builds
+
+By default, checkers are run on all subprojects of the project to which the plugin
+is applied. If you wish to disable this behavior, set the `applyToSubprojects`
+flag to `false` (note that disabling this behavior will require you to configure
+each subproject by hand in an appropriate `build.gradle` file):
+
+```groovy
+checkerFramework {
+  applyToSubprojects = false
+}
+```
+
+In most projects with subprojects, you will still want to avoid attempting to configure
+the top-level project (which is usually not a Java project). We therefore recommend moving
+all Checker Framework configuration (the `checkerFramework` block and any `dependencies`)
+into a `subprojects` block. For example:
+
+```groovy
+subprojects { subproject ->
+  checkerFramework {
+    checkers = ['org.checkerframework.checker.index.IndexChecker']
+  }
+  dependencies {
+    checkerFramework 'org.checkerframework:checker:2.9.0'
+    implementation 'org.checkerframework:checker-qual:2.9.0'
+  }
+}
+```
+
 ### Incompatibility with Error Prone
 
 [Error Prone](https://errorprone.info/)
@@ -145,7 +175,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.16' apply false
+  id 'org.checkerframework' version '0.3.17' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -230,7 +260,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.16-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.17-SNAPSHOT'
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ dependencies {
 You can also use a locally-built version of the Checker Framework:
 
 ```groovy
-// To use a local-built Checker Framework, run gradle with "-PcfLocal".
+// To use a locally-built Checker Framework, run gradle with "-PcfLocal".
 if (project.hasProperty("cfLocal")) {
   def cfHome = String.valueOf(System.getenv("CHECKERFRAMEWORK"))
   dependencies {
@@ -121,11 +121,12 @@ Gradle project, you can use the following code to skip this plugin's version che
 which reads the manifest file of the version of the Checker Framework you are actually
 using:
 
-```groovy
-checkerFramework {
-  skipVersionCheck = true
-}
-```
+  ```groovy
+  checkerFramework {
+    skipVersionCheck = true
+  }
+  ```
+
 
 ### Multi-project builds
 

--- a/README.md
+++ b/README.md
@@ -130,16 +130,7 @@ checkerFramework {
 ### Multi-project builds
 
 By default, checkers are run on all subprojects of the project to which the plugin
-is applied. If you wish to disable this behavior, set the `applyToSubprojects`
-flag to `false` (note that disabling this behavior will require you to configure
-each subproject by hand in an appropriate `build.gradle` file):
-
-```groovy
-checkerFramework {
-  applyToSubprojects = false
-}
-```
-
+is applied.
 In most projects with subprojects, you will still want to avoid attempting to configure
 the top-level project (which is usually not a Java project). We therefore recommend moving
 all Checker Framework configuration (the `checkerFramework` block and any `dependencies`)
@@ -154,6 +145,19 @@ subprojects { subproject ->
     checkerFramework 'org.checkerframework:checker:2.9.0'
     implementation 'org.checkerframework:checker-qual:2.9.0'
   }
+}
+```
+
+If you want to apply the plugin only to projects for which it has been
+specifically request (for instance, if you
+wish to run a checker on a parent project and only some of its child projects),
+set the `applyToSubprojects`
+flag to `false` (note that disabling this behavior will require you to configure
+each subproject by hand in its `build.gradle` file by applying the plugin manually):
+
+```groovy
+checkerFramework {
+  applyToSubprojects = false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ if (project.hasProperty("cfLocal")) {
 
   Here is how to prevent checkers from being applied to test targets:
 
-```groovy
-checkerFramework {
-  excludeTests = true
-}
-```
+  ```groovy
+  checkerFramework {
+    excludeTests = true
+  }
+  ```
 
   The check for test targets is entirely syntactic: this option will not apply the checkers
   to any task whose name includes "test", ignoring case.

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ using:
 By default, checkers are run on all subprojects of the project to which the plugin
 is applied.
 
-In most projects with subprojects, you will still want to avoid attempting to configure
-the top-level project (which is usually not a Java project). We therefore recommend moving
-all Checker Framework configuration (the `checkerFramework` block and any `dependencies`)
-into a `subprojects` block. For example:
+In most projects with subprojects, the top-level project is not a Java
+project.  You should not configure such a non-Java block.  Instead, move
+all Checker Framework configuration (the `checkerFramework` block and any
+`dependencies`) into a `subprojects` block. For example:
 
 ```groovy
 subprojects { subproject ->
@@ -150,18 +150,18 @@ subprojects { subproject ->
 }
 ```
 
-If you want to apply the plugin only to projects for which it has been
-specifically request (for instance, if you
-wish to run a checker on a parent project and only some of its child projects),
-set the `applyToSubprojects`
-flag to `false` (note that disabling this behavior will require you to configure
-each subproject by hand in its `build.gradle` file by applying the plugin manually):
+To not apply the plugin only to subprojects, set the `applyToSubprojects`
+flag to `false`:
 
 ```groovy
 checkerFramework {
   applyToSubprojects = false
 }
 ```
+
+Then, apply the plugin to the `build.gradle` in each subproject where you
+do want to run the checker.
+
 
 ### Incompatibility with Error Prone
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ if (project.hasProperty("cfLocal")) {
 ### Other options
 
 * By default, the plugin applies the selected checkers to all `JavaCompile` targets.
-The plugin includes a rudimentary option for preventing checkers from being applied
-to test targets. To use it, add the following to the `checkerFramework` block:
+
+  Here is how to prevent checkers from being applied to test targets:
 
 ```groovy
 checkerFramework {
@@ -113,8 +113,8 @@ checkerFramework {
 }
 ```
 
-The check for test targets is entirely syntactic: this option will not apply the checkers
-to any task whose name includes "test", ignoring case. The default value is `false`.
+  The check for test targets is entirely syntactic: this option will not apply the checkers
+  to any task whose name includes "test", ignoring case.
 
 * If you encounter errors of the form `zip file name too long` when configuring your
 Gradle project, you can use the following code to skip this plugin's version check,

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ using:
 
 By default, checkers are run on all subprojects of the project to which the plugin
 is applied.
+
 In most projects with subprojects, you will still want to avoid attempting to configure
 the top-level project (which is usually not a Java project). We therefore recommend moving
 all Checker Framework configuration (the `checkerFramework` block and any `dependencies`)

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.16'
+version '0.3.17'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -14,8 +14,8 @@ class CheckerFrameworkExtension {
   // the standard version check which unzips a jar to look at its manifest.
   Boolean skipVersionCheck = false
 
-  // Automatically apply the checker options to all gradle subprojects by default,
-  // to reduce configuration boilerplate for large projects. Use this option to disable
+  // If true, apply the checker options to all gradle subprojects by default,
+  // to reduce configuration boilerplate for large projects. Set to false to disable
   // the application of checkers to subprojects automatically. If you need to apply
   // different typecheckers to different subprojects, add the checkers in
   // the subproject's build file rather than the parent's build file.

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -13,4 +13,11 @@ class CheckerFrameworkExtension {
   // If you encounter "zip file too large" errors, you can set this flag to avoid
   // the standard version check which unzips a jar to look at its manifest.
   Boolean skipVersionCheck = false
+
+  // Automatically apply the checker options to all gradle subprojects by default,
+  // to reduce configuration boilerplate for large projects. Use this option to disable
+  // the application of checkers to subprojects automatically. If you need to apply
+  // different typecheckers to different subprojects, add the checkers in
+  // the subproject's build file rather than the parent's build file.
+  Boolean applyToSubprojects = true
 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -114,11 +114,9 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
 
   private static configureProject(Project project, CheckerFrameworkExtension userConfig) {
 
-    def jdkVersion = ANNOTATED_JDK_NAME_JDK8
-
     // Create a map of the correct configurations with dependencies
     def dependencyMap = [
-            [name: "${ANNOTATED_JDK_CONFIGURATION}", descripion: "${ANNOTATED_JDK_CONFIGURATION_DESCRIPTION}"]: "org.checkerframework:${jdkVersion}:${LIBRARY_VERSION}",
+            [name: "${ANNOTATED_JDK_CONFIGURATION}", descripion: "${ANNOTATED_JDK_CONFIGURATION_DESCRIPTION}"]: "org.checkerframework:${ANNOTATED_JDK_NAME_JDK8}:${LIBRARY_VERSION}",
             [name: "${CONFIGURATION}", descripion: "${ANNOTATED_JDK_CONFIGURATION_DESCRIPTION}"]              : "${CHECKER_DEPENDENCY}",
             [name: "${JAVA_COMPILE_CONFIGURATION}", descripion: "${CONFIGURATION_DESCRIPTION}"]               : "${CHECKER_QUAL_DEPENDENCY}",
             [name: "${TEST_COMPILE_CONFIGURATION}", descripion: "${CONFIGURATION_DESCRIPTION}"]               : "${CHECKER_QUAL_DEPENDENCY}",


### PR DESCRIPTION
See the documentation in `README.md`.

I also needed to split the `configureProject` method into two so that appropriate configurations exist even in non-Java parts of the project.