### PR TITLE
Make sure configurations are actually applied to appropriate plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.17'
+    id 'org.checkerframework' version '0.3.18'
 }
 
 apply plugin: 'org.checkerframework'
@@ -181,7 +181,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.17' apply false
+  id 'org.checkerframework' version '0.3.18' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -266,7 +266,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.17-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.18-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.17'
+version '0.3.18'
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
Fixes a regression reported by @mernst on https://github.com/plume-lib/bibtex-clean

The issue was that the subproject support introduced in #25 did not correctly handle configuring single project builds that relied on the plugin to provide all CF dependencies.