### PR TITLE
Don't attempt to delombok tasks with empty inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.20'
+    id 'org.checkerframework' version '0.3.21'
 }
 
 apply plugin: 'org.checkerframework'
@@ -181,7 +181,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.20' apply false
+  id 'org.checkerframework' version '0.3.21' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -266,7 +266,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.20-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.21-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.20'
+version '0.3.21'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -91,7 +91,7 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
 
               // delombokTask can still be null; for example, if the code contains a compileScala task
               // Also, if we're skipping test tasks, don't bother delombok'ing them.
-              if (delombokTask != null
+              if (delombokTask != null && !compile.getSource().isEmpty()
                       && !(userConfig.excludeTests && delombokTask.name.toLowerCase().contains("test"))) {
 
                 // The lombok plugin's default formatting is pretty-printing, without the @Generated annotations


### PR DESCRIPTION
Attempting to do so causes Gradle to fail with an error of the form:

```
* What went wrong:
Execution failed for task ':taskName'.
> no source files or class names
```

This came up in an object construction checker case study, on an empty test task for a sub-project whose tests were written in Scala. This error was issued for the corresponding `compileTestJava` task when `excludeTests` was set to `false`.

I confirmed locally that this version resolves the issue.