### PR TITLE
Change condition for use of error-prone javac

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.3.24'
+    id 'org.checkerframework' version '0.3.25'
 }
 
 apply plugin: 'org.checkerframework'
@@ -181,7 +181,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.3.24' apply false
+  id 'org.checkerframework' version '0.3.25' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -266,7 +266,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.24-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.3.25-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.3.24'
+version '0.3.25'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -186,8 +186,10 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
         // wasn't specified by the user.
         versionString = actualCFDependencySet.iterator().next().getVersion()
       }
-      // The array access is safe because all CF version strings have at least one . in them.
-      def isCFThreePlus = versionString.tokenize(".")[0].toInteger() >= 3
+      // The array accesses are safe because all CF version strings have at least two . in them.
+      def majorVersion = versionString.tokenize(".")[0].toInteger()
+      def minorVersion = versionString.tokenize(".")[1].toInteger()
+      def isCFThreePlus = majorVersion >= 3 || (majorVersion == 2 && minorVersion >= 11)
 
       boolean needErrorProneJavac = javaVersion.java8 && isCFThreePlus
 


### PR DESCRIPTION
Checker Framework 2.11.0 will also require Error-prone Javac, apparently, according to @mernst 