### PR TITLE
Update java9 logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,22 @@ When using a Checker Framework version that uses the Java 9+ compiler API
    (in particular, the Error Prone Java compiler from
    [com.google.errorprone:javac](https://mvnrepository.com/artifact/com.google.errorprone/javac)).
 
+When running the plugin on a Java 9+ project that uses modules,
+you may need to add annotations to the module path. First add
+`requires org.checkerframework.checker.qual;` to your `module-info.java`.  The Checker
+Framework inserts inferred annotations into bytecode even if none appear in source code,
+so you must do this even if you write no annotations in your code.
+
+Then, add this line to the `checkerFramework` block to add the `checker-qual.jar`
+artifact (which only contains annotations) to the module path:
+
+```
+checkerFramework {
+  extraJavacArgs = [
+    '--module-path', compileOnly.asPath
+  ]
+}
+```
 
 ## Lombok compatibility
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.4.3'
+    id 'org.checkerframework' version '0.4.4'
 }
 
 apply plugin: 'org.checkerframework'
@@ -186,7 +186,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.4.3' apply false
+  id 'org.checkerframework' version '0.4.4' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -269,7 +269,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.4.3-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.4.4-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.3'
+version '0.4.4'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -205,8 +205,8 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
                     project.property('sourceCompatibility')
 
     // Check Java version.
-    if (javaVersion.java7) {
-      throw new IllegalStateException("The Checker Framework does not support Java 7.")
+    if (!javaVersion.isJava8Compatible()) {
+      throw new IllegalStateException("The Checker Framework does not support Java versions before 8.")
     }
 
     // Apply checker to project

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -256,6 +256,15 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
               "-Xbootclasspath/p:${project.configurations.errorProneJavac.asPath}".toString()
             ]
           }
+
+          // When running on Java 9+ code, the Checker Framework needs reflective access
+          // to some JDK classes. Pass the arguments that make that possible.
+          if (javaVersion.isJava9Compatible()) {
+            compile.options.forkOptions.jvmArgs += [
+                    "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+            ]
+          }
+
           compile.options.compilerArgs += [
             "-Xbootclasspath/p:${project.configurations.checkerFrameworkAnnotatedJDK.asPath}".toString()
           ]


### PR DESCRIPTION
This brings the plugin into line with the instructions for running on plain javac in https://github.com/typetools/checker-framework/pull/2794, which was recently merged into the mainline CF, and should be part of the 3.0 release.

I also fixed a minor bug with the check for old Java versions while I was there in the codebase.

@smillst