### PR TITLE
Fix local dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.4.7'
+    id 'org.checkerframework' version '0.4.8'
 }
 
 apply plugin: 'org.checkerframework'
@@ -186,7 +186,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.4.7' apply false
+  id 'org.checkerframework' version '0.4.8' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -285,7 +285,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.4.7-SNAPSHOT'
+    classpath 'gradle.plugin.org.checkerframework:checkerframework-gradle-plugin:0.4.8-SNAPSHOT'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.7'
+version '0.4.8'
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
Adds code to avoid putting the default Checker Framework dependencies jars into dependency configurations when an equivalent file has already been provided as a local dependency.

This behavior already works for external dependencies (that is, if a user depends on an older/newer version of the framework via Maven, the user-specified jar will be the only one).