### PR TITLE
Respect existing -AsuppressWarnings arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.4.10'
+    id 'org.checkerframework' version '0.4.11'
 }
 
 apply plugin: 'org.checkerframework'
@@ -74,7 +74,7 @@ dependencies {
 
 ### Specifying a Checker Framework version
 
-Version 0.4.10 of this plugin uses Checker Framework version 3.0.0 by default.
+Version 0.4.11 of this plugin uses Checker Framework version 3.0.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -188,7 +188,7 @@ plugins {
   id "net.ltgt.errorprone-base" version "0.0.16" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.4.10' apply false
+  id 'org.checkerframework' version '0.4.11' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {
@@ -290,7 +290,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'org.checkerframework:checkerframework-gradle-plugin:0.4.10'
+    classpath 'org.checkerframework:checkerframework-gradle-plugin:0.4.11'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.10'
+version '0.4.11'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -147,7 +147,12 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
         }
         // lombok-generated code will always causes these warnings, because their default formatting is wrong
         // and can't be changed
-        userConfig.extraJavacArgs += "-AsuppressWarnings=type.anno.before.modifier"
+        def swKeys = userConfig.extraJavacArgs.find { option -> option.startsWith("-AsuppressWarnings")}
+        if (swKeys == null) {
+          userConfig.extraJavacArgs += "-AsuppressWarnings=type.anno.before.modifier"
+        } else {
+          userConfig.extraJavacArgs += swKeys + ",type.anno.before.modifier"
+        }
       }
     })
   }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -145,7 +145,7 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
             }
           }
         }
-        // lombok-generated code will always causes these warnings, because their default formatting is wrong
+        // lombok-generated code will always cause these warnings, because their default formatting is wrong
         // and can't be changed
         def swKeys = userConfig.extraJavacArgs.find { option -> option.startsWith("-AsuppressWarnings")}
         if (swKeys == null) {


### PR DESCRIPTION
This was the cause of the unsuppressed `type.anno.before.decl.anno` warnings in the Object Construction Checker Lombok benchmarks