### PR TITLE
Improve safety of code that decides whether to use ErrorProne javac

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dependencies {
 
 ### Specifying a Checker Framework version
 
-Version 0.4.15 of this plugin uses Checker Framework version 3.3.0 by default.
+Version 0.4.16 of this plugin uses Checker Framework version 3.3.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ checkerFramework {
 }
 ```
 
-Note that doing so will cause *all* tools (including Javac itself) to being issuing
+Note that doing so will cause *all* tools (including Javac itself) to begin issuing
 warnings in the code that Lombok generates.
 
 ## Using a locally-built plugin

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dependencies {
 
 ### Specifying a Checker Framework version
 
-Version 0.4.14 of this plugin uses Checker Framework version 3.3.0 by default.
+Version 0.4.15 of this plugin uses Checker Framework version 3.3.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -261,6 +261,19 @@ This plugin automatically interacts with
 the [Lombok Gradle Plugin](https://plugins.gradle.org/plugin/io.freefair.lombok)
 to delombok your source code before it is passed to the Checker Framework
 for typechecking. This plugin does not support any other use of Lombok.
+
+By default, Lombok suppresses all warnings in the code it generates. If you
+want to typecheck the code that Lombok generates, use the `suppressLombokWarnings`
+configuration key:
+
+```
+checkerFramework {
+  suppressLombokWarnings = false
+}
+```
+
+Note that doing so will cause *all* tools (including Javac itself) to being issuing
+warnings in the code that Lombok generates.
 
 ## Using a locally-built plugin
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.15'
+version '0.4.16'
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.14'
+version '0.4.15'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -20,4 +20,9 @@ class CheckerFrameworkExtension {
   // different typecheckers to different subprojects, add the checkers in
   // the subproject's build file rather than the parent's build file.
   Boolean applyToSubprojects = true
+
+  // If true, generate @SuppressWarnings("all") annotations on Lombok-generated code,
+  // which is Lombok's default but could permit unsoundness from the Checker Framework.
+  // For an example, see https://github.com/kelloggm/checkerframework-gradle-plugin/issues/85.
+  Boolean suppressLombokWarnings = true
 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -135,9 +135,12 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
                 // The lombok plugin's default formatting is pretty-printing, without the @Generated annotations
                 // that we need to recognize lombok'd code.
                 delombokTask.format.put('generated', 'generate')
-                // Also re-add suppress warnings annotations so that we don't get warnings from generated
-                // code.
-                delombokTask.format.put('suppressWarnings', 'generate')
+
+                if (userConfig.suppressLombokWarnings) {
+                  // Also re-add suppress warnings annotations so that we don't get warnings from generated
+                  // code.
+                  delombokTask.format.put('suppressWarnings', 'generate')
+                }
 
                 compile.dependsOn(delombokTask)
                 compile.setSource(delombokTask.target.getAsFile().get())


### PR DESCRIPTION
Fixes https://github.com/kelloggm/checkerframework-gradle-plugin/issues/89.

Do not review until #86 is merged, because I released a version of the plugin (0.4.16) with this code in it so that a user could test it right away.