### PR TITLE
Do not apply to subprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.5.0-SNAPSHOT'
+    id 'org.checkerframework' version '0.5.0'
 }
 
 apply plugin: 'org.checkerframework'
@@ -74,7 +74,7 @@ dependencies {
 
 ### Specifying a Checker Framework version
 
-Version 0.4.14 of this plugin uses Checker Framework version 3.3.0 by default.
+Version 0.5.0 of this plugin uses Checker Framework version 3.3.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.4.13'
+    id 'org.checkerframework' version '0.5.0-SNAPSHOT'
 }
 
 apply plugin: 'org.checkerframework'
@@ -139,9 +139,6 @@ using:
 
 ### Multi-project builds
 
-By default, checkers are run on all subprojects of the project to which the plugin
-is applied.
-
 In most projects with subprojects, the top-level project is not a Java
 project.  You should not configure such a non-Java project.  Instead, move
 all Checker Framework configuration (the `checkerFramework` block and any
@@ -159,18 +156,8 @@ subprojects { subproject ->
 }
 ```
 
-To not apply the plugin to all subprojects, set the `applyToSubprojects`
-flag to `false`:
-
-```groovy
-checkerFramework {
-  applyToSubprojects = false
-}
-```
-
-Then, apply the plugin to the `build.gradle` in each subproject where you
-do want to run the checker.
-
+Alternately, apply the plugin to the `build.gradle` in each subproject where you
+want to run a checker.
 
 ### Incompatibility with Error Prone
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.5.0-SNAPSHOT'
+version '0.5.0'
 
 gradlePlugin {
     plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.4.14'
+version '0.5.0-SNAPSHOT'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -13,11 +13,4 @@ class CheckerFrameworkExtension {
   // If you encounter "zip file too large" errors, you can set this flag to avoid
   // the standard version check which unzips a jar to look at its manifest.
   Boolean skipVersionCheck = false
-
-  // If true, apply the checker options to all gradle subprojects by default,
-  // to reduce configuration boilerplate for large projects. Set to false to disable
-  // the application of checkers to subprojects automatically. If you need to apply
-  // different typecheckers to different subprojects, add the checkers in
-  // the subproject's build file rather than the parent's build file.
-  Boolean applyToSubprojects = true
 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -50,6 +50,9 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
   private final static def manifestLocation = "/checkerframework/"
 
   @Override void apply(Project project) {
+
+    println("applying to : "  + project)
+
     // Either get an existing CF config, or create a new one if none exists
     CheckerFrameworkExtension userConfig = project.extensions.findByType(CheckerFrameworkExtension.class)?:
             project.extensions.create("checkerFramework", CheckerFrameworkExtension)
@@ -67,11 +70,6 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
       // Ensure that dependencies and configurations are available, even if no Java/Android plugins were found,
       // to support configuration in a super project with many Java/Android subprojects.
       configureProject(project, userConfig)
-    }
-
-    // Also apply the checker to all subprojects
-    if (userConfig.applyToSubprojects) {
-      project.subprojects { subproject -> apply(subproject) }
     }
 
     project.afterEvaluate {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -50,9 +50,6 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
   private final static def manifestLocation = "/checkerframework/"
 
   @Override void apply(Project project) {
-
-    println("applying to : "  + project)
-
     // Either get an existing CF config, or create a new one if none exists
     CheckerFrameworkExtension userConfig = project.extensions.findByType(CheckerFrameworkExtension.class)?:
             project.extensions.create("checkerFramework", CheckerFrameworkExtension)


### PR DESCRIPTION
As pointed out by #88, the logic for applying to subprojects was impossible to disable. I don't know why I ever thought that it had worked.

Regardless, my review of stack overflow and the gradle documentation agrees that automatically applying to subprojects is an anti-pattern, so this PR seeks to remove that behavior. As a plus, the documentation for multiproject builds is actually now simpler, though users might need to write a bit more buildscript code.

Bumped the minor version, since this does change the behavior in an incompatible way.