### PR TITLE
Add per-task `skipCheckerFramework` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.5.5'
+    id 'org.checkerframework' version '0.5.6'
 }
 
 apply plugin: 'org.checkerframework'
@@ -80,7 +80,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.5.5 of this plugin uses Checker Framework version 3.5.0 by default.
+Version 0.5.6 of this plugin uses Checker Framework version 3.5.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -162,7 +162,7 @@ plugin to the top-level project. For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.5.5' apply false
+  id 'org.checkerframework' version '0.5.6' apply false
 }
 
 subprojects { subproject ->
@@ -205,7 +205,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.5.5' apply false
+  id 'org.checkerframework' version '0.5.6' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ if (project.hasProperty("cfLocal")) {
 }
 ```
 
+### Per-Task Configuration
+
+You can also use a `checkerFramework` block to configure individual tasks. This
+can be useful for skipping the Checker Framework on generated code:
+
+```build.gradle
+tasks.withType(JavaCompile).configureEach {
+  // Don't run the checker on generated code.
+  if (name.equals("compileMainGeneratedDataTemplateJava")
+      || name.equals("compileMainGeneratedRestJava")) {
+    checkerFramework {
+      skipCheckerFramework = true
+    }
+  }
+}
+```
+
+Currently, the only supported option is `skipCheckerFramework`.
+
 ### Other options
 
 * You can disable the Checker Framework temporarily (e.g. when testing something unrelated)

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.5.5'
+version '0.5.6'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkTaskExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkTaskExtension.groovy
@@ -1,0 +1,11 @@
+package org.checkerframework.gradle.plugin
+
+/**
+ * A Gradle extension for Checker Framework configuration for compile tasks.
+ */
+class CheckerFrameworkTaskExtension {
+  /**
+   * If the Checker Framework should be skipped for this compile task.
+   */
+  Boolean skipCheckerFramework = false
+}


### PR DESCRIPTION
- Introduces `CheckerFrameworkTaskExtension` for per-task checker configuration.
- Currently, the only option is `skipCheckerFramework`.

Partially fixes #110 (task-dependent configuration) and #106 (skip checks for autogenerated code).

We can use this to skip checking code generated by [rest.li's](https://github.com/linkedin/rest.li) Pegasus compiler:

```build.gradle
subprojects {
  plugins.withType(JavaPlugin) {
    project.apply plugin: 'org.checkerframework'
    tasks.withType(JavaCompile).configureEach {
      // Don't run the checker on generated code.
      if (name.equals("compileMainGeneratedDataTemplateJava")
          || name.equals("compileMainGeneratedRestJava")) {
        checkerFramework {
          skipCheckerFramework = true
        }
      }
    }
  }
}
```
