### PR TITLE
Don't use lazy configuration on a Java 8 JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.5.8'
+    id 'org.checkerframework' version '0.5.9'
 }
 
 apply plugin: 'org.checkerframework'
@@ -80,7 +80,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.5.8 of this plugin uses Checker Framework version 3.6.0 by default.
+Version 0.5.9 of this plugin uses Checker Framework version 3.6.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -181,7 +181,7 @@ plugin to the top-level project. For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.5.8' apply false
+  id 'org.checkerframework' version '0.5.9' apply false
 }
 
 subprojects { subproject ->
@@ -224,7 +224,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.5.8' apply false
+  id 'org.checkerframework' version '0.5.9' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.5.8'
+version '0.5.9'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -65,7 +65,9 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
    * Gradle documentation: Task Configuration Avoidance</a>
    */
   private static <S extends Task> void configureTasks(Project project, Class<S> taskType, Action<? super S> configure) {
-    if (GradleVersion.current() < GradleVersion.version("4.9")) {
+    // TODO: why does lazy configuration fail on Java 8 JVMs? https://github.com/typetools/checker-framework/pull/3557
+    if (GradleVersion.current() < GradleVersion.version("4.9")
+            || !JavaVersion.current().isJava9Compatible()) {
       project.tasks.withType(taskType).all configure
     } else {
       project.tasks.withType(taskType).configureEach configure


### PR DESCRIPTION
Lazy configuration of tasks is better, but it has known incompatibilities with `afterEvaluate`, which we use. This caused a problem that was detected in the CF's integration tests: https://github.com/typetools/checker-framework/pull/3557

I looked for a clean solution to this problem but didn't find one - the right solution, I think, is to avoid using `afterEvaluate` at all, but I haven't found a good alternative yet (or I still don't understand Gradle well enough...). This solution should cause those CF tests to pass, and will hopefully help other consumers that might be encountering the same problem. It will, however, incur a performance penalty in Java 8 builds. I think it's worth it as a quick and dirty solution to avoid the crash in the linked PR.