### PR TITLE
Support automatic incremental compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.5'
+    id 'org.checkerframework' version '0.6.6'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.5 of this plugin uses Checker Framework version 3.21.0 by default.
+Version 0.6.6 of this plugin uses Checker Framework version 3.21.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -124,6 +124,24 @@ if (project.hasProperty("cfLocal")) {
     checkerFramework files(cfHome + "/checker/dist/checker.jar")
   }
 }
+```
+
+### Incremental compilation
+
+By default, the plugin assumes that all checkers are "aggregating incremental annotation processors"
+according to the Gradle terminology 
+[here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing).
+This assumption speeds up builds by enabling incremental compilation, but is unsafe: Gradle's
+documentation warns that annotation processors that use internal Javac APIs may crash, because
+Gradle wraps some of those APIs. The Checker Framework does use internal Javac APIs, so you
+might encounter such a crash, which would appear as a `ClassCastException` referencing some
+internal Javac class. If you encounter such a crash, you can disable incremental
+compilation in your build using the following code in your `checkerFramework` configuration block:
+
+```groovy
+  checkerFramework {
+    incrementalize = false
+  }
 ```
 
 ### Per-Task Configuration
@@ -196,7 +214,7 @@ plugin to the top-level project. For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.5' apply false
+  id 'org.checkerframework' version '0.6.6' apply false
 }
 
 subprojects { subproject ->
@@ -239,7 +257,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.5' apply false
+  id 'org.checkerframework' version '0.6.6' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ if (project.hasProperty("cfLocal")) {
 
 ### Incremental compilation
 
-By default, the plugin assumes that all checkers are "aggregating incremental annotation processors"
+By default, the plugin assumes that all checkers are "isolating incremental annotation processors"
 according to the Gradle terminology 
 [here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing).
 This assumption speeds up builds by enabling incremental compilation, but is unsafe: Gradle's

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.5'
+version '0.6.6'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -21,4 +21,11 @@ class CheckerFrameworkExtension {
 
   // Flag to disable the CF easily, from e.g. the command-line.
   Boolean skipCheckerFramework = false
+
+  // Flag to disable automatic incremental compilation. By default, the Checker Framework
+  // assumes that all checkers are incremental with type "aggregating". Gradle's documentation
+  // suggests that annotation processors that interact with Javac APIs might crash because
+  // Gradle wraps some Javac APIs, so if you encounter such a crash you can disable incremental
+  // compilation using this flag.
+  Boolean incrementalize = true
 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkExtension.groovy
@@ -23,7 +23,7 @@ class CheckerFrameworkExtension {
   Boolean skipCheckerFramework = false
 
   // Flag to disable automatic incremental compilation. By default, the Checker Framework
-  // assumes that all checkers are incremental with type "aggregating". Gradle's documentation
+  // assumes that all checkers are incremental with type "isolating". Gradle's documentation
   // suggests that annotation processors that interact with Javac APIs might crash because
   // Gradle wraps some Javac APIs, so if you encounter such a crash you can disable incremental
   // compilation using this flag.

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -372,6 +372,7 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
       if (createManifestTask == null) {
         createManifestTask = project.task(checkerFrameworkManifestCreationTaskName, type: CreateManifestTask)
         createManifestTask.checkers = userConfig.checkers
+        createManifestTask.incrementalize = userConfig.incrementalize
       }
 
       configureTasks(project, AbstractCompile, { AbstractCompile compile ->

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
@@ -46,13 +46,15 @@ class CreateManifestTask extends DefaultTask {
                 gradleManifestFile.delete()
                 gradleManifestFile.createNewFile()
             }
-            // treat all checkers as aggregating annotation APs, since they might reason about more
-            // than just a single annotated type at once (in theory - I think most checkers are actually
-            // "isolating", but verifying that is TODO)
+            // The following code treats all checkers as isolating annotation processors.
+            // I think this is the right decision: checkers should be reasoning about
+            // each method in isolation. But, we provide a way to disable incremental
+            // compilation in the event that this decision is breaking for some particular
+            // checker.
             def gradleManifestFileContents = ""
-            // do a join, but add ",AGGREGATING" after each entry
+            // do a join, but add ",ISOLATING" after each entry
             for (int i = 0; i < this.checkers.length; i++) {
-                gradleManifestFileContents += checkers[i] + ",AGGREGATING"
+                gradleManifestFileContents += checkers[i] + ",ISOLATING"
                 if (i != checkers.length - 1) {
                     gradleManifestFileContents += "\n"
                 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
@@ -16,8 +16,15 @@ class CreateManifestTask extends DefaultTask {
     private final static String manifestDirectoryName = "checkerframework/META-INF/services/"
     private final static String manifestFileName = "javax.annotation.processing.Processor"
 
+    // Mark the checkers as incremental annotation processors for Gradle
+    private final static String gradleManifestDirectoryName = "checkerframework/META-INF/gradle/"
+    private final static String gradleManifestFileName = "incremental.annotation.processors"
+
     @Input
     String[] checkers = []
+
+    @Input
+    boolean incrementalize = true
 
     /**
      * Creates a manifest file listing all the checkers to run.
@@ -31,6 +38,28 @@ class CreateManifestTask extends DefaultTask {
             manifestFile.createNewFile()
         }
         manifestFile << this.checkers.join('\n')
+
+        if (incrementalize) {
+            def gradleManifestDir = project.mkdir "${project.buildDir}/${gradleManifestDirectoryName}"
+            def gradleManifestFile = project.file("${gradleManifestDir.absolutePath}/${gradleManifestFileName}")
+            if (!gradleManifestFile.createNewFile()) {
+                gradleManifestFile.delete()
+                gradleManifestFile.createNewFile()
+            }
+            // treat all checkers as aggregating annotation APs, since they might reason about more
+            // than just a single annotated type at once (in theory - I think most checkers are actually
+            // "isolating", but verifying that is TODO)
+            def gradleManifestFileContents = ""
+            // do a join, but add ",AGGREGATING" after each entry
+            for (int i = 0; i < this.checkers.length; i++) {
+                gradleManifestFileContents += checkers[i] + ",AGGREGATING"
+                if (i != checkers.length - 1) {
+                    gradleManifestFileContents += "\n"
+                }
+            }
+
+            gradleManifestFile << gradleManifestFileContents
+        }
     }
 
     /**
@@ -40,5 +69,14 @@ class CreateManifestTask extends DefaultTask {
     @OutputFile
     def getManifestLocation() {
         return "${project.buildDir}/${manifestDirectoryName}/${manifestFileName}"
+    }
+
+    /**
+     * Required so that this can incrementalized correctly, and so that `gradle clean build` behaves
+     * the same as `gradle clean ; gradle build`.
+     */
+    @OutputFile
+    def getGradleManifestLocation() {
+        return "${project.buildDir}/${gradleManifestDirectoryName}/${gradleManifestFileName}"
     }
 }


### PR DESCRIPTION
An attempt to resolve the discussion at https://groups.google.com/g/checker-framework-discuss/c/RQ31xTNFFNw.

I was surprised that this appears to just work when I tested it on a simple project. But, it might be that the CF doesn't actually do whatever it is that the Gradle docs are warning about wrt internal Javac APIs (or we don't anymore - I think I tested something similar to this back in 2019 when I wrote https://github.com/typetools/checker-framework/issues/2401).

This would fix https://github.com/typetools/checker-framework/issues/2401.