### PR TITLE
Remove Lombok plugin version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.21'
+    id 'org.checkerframework' version '0.6.22'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.21 of this plugin uses Checker Framework version 3.29.0 by default.
+Version 0.6.22 of this plugin uses Checker Framework version 3.29.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -214,7 +214,7 @@ plugin to the top-level project. For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.21' apply false
+  id 'org.checkerframework' version '0.6.22' apply false
 }
 
 subprojects { subproject ->
@@ -257,7 +257,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.21' apply false
+  id 'org.checkerframework' version '0.6.22' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.21'
+version '0.6.22'
 
 gradlePlugin {
     plugins {

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -105,9 +105,6 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
     project.getPlugins().withType(io.freefair.gradle.plugins.lombok.LombokPlugin.class, new Action<LombokPlugin>() {
       void execute(LombokPlugin lombokPlugin) {
 
-        def lombokPluginVersion = project.buildscript.configurations.classpath.resolvedConfiguration.resolvedArtifacts.collect {
-          it.moduleVersion.id }.findAll { it.name == 'lombok-plugin' }.first().version
-
         def warnAboutCMCLombokInteraction =
                 (userConfig.checkers.contains('org.checkerframework.checker.objectconstruction.ObjectConstructionChecker')
                 || userConfig.checkers.contains("org.checkerframework.checker.calledmethods.CalledMethodsChecker"))
@@ -117,20 +114,7 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
                 "Ensure that your lombok.config file contains 'lombok.addLombokGeneratedAnnotation = true', " +
                 "or all warnings related to misuse of Lombok builders will be disabled."
 
-        if (lombokPluginVersion.tokenize('.')[0].toInteger() <= 5) {
-          // Support for generating Lombok configs was removed from the Lombok plugin
-          // starting in version 6.0.0.
-
-          // Ensure that the lombok config is set to emit @Generated annotations.
-          lombokPlugin.configureForJacoco()
-          // If config generation is enabled, automatically produce an appropriate config file.
-          def generateLombokConfig = lombokPlugin.generateLombokConfig.get()
-          if (generateLombokConfig.isEnabled()) {
-            generateLombokConfig.generateLombokConfig()
-          } else if (warnAboutCMCLombokInteraction) {
-            LOG.warn(cmcLombokInteractionWarningMessage)
-          }
-        } else if (warnAboutCMCLombokInteraction) {
+        if (warnAboutCMCLombokInteraction) {
           // Because we don't know whether the user has done this or not, use the info logging level instead of warning,
           // as above, where we know that no config was generated. And, we want to avoid nagging the user.
           LOG.info(cmcLombokInteractionWarningMessage)


### PR DESCRIPTION
Hopefully this should fix #233 and #234; I followed the suggestion from @zman0900 in #233 to just remove the version-specific configuration code for the lombok plugin, which is now only useful for somewhat old versions of that plugin (the last relevant release was 5.3.3 in April 2021, almost 2 years ago).

@zman0900 and @vkorenev, I published a special release of this plugin as version `0.6.21.1`. If either or both of you would be willing to try that version out and test if it resolves the issue you observed, I'd be grateful.