### PR TITLE
Upgrade that fixes an incompatibility with Gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.ben-manes.versions' version '0.42.0'
-    id 'com.gradle.plugin-publish' version '1.0.0'
+    id 'com.gradle.plugin-publish' version '1.1.0'
     id 'java-gradle-plugin'
     id 'groovy'
     id 'maven-publish'


### PR DESCRIPTION
See the "NOTE" at the top of the page here: https://plugins.gradle.org/docs/publish-plugin

I already used this branch to publish version 0.6.29, so we have some evidence that this works. On the current master branch, running `./gradlew publishPlugins` on a machine with the correct key results in the following exception:
```
Execution failed for task ':publishPlugins'.
> class org.gradle.api.internal.provider.DefaultSetProperty cannot be cast to class java.util.Collection (org.gradle.api.internal.provider.DefaultSetProperty is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @21213b92; java.util.Collection is in module java.base of loader 'bootstrap')
```