### PR TITLE
Avoid deprecation (a different one this time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.31'
+    id 'org.checkerframework' version '0.6.32'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.31 of this plugin uses Checker Framework version 3.37.0 by default.
+Version 0.6.32 of this plugin uses Checker Framework version 3.37.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -228,7 +228,7 @@ top-level project is a Java project).  For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.31' apply false
+  id 'org.checkerframework' version '0.6.32' apply false
 }
 
 subprojects { subproject ->
@@ -269,7 +269,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.31' apply false
+  id 'org.checkerframework' version '0.6.32' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.31'
+version '0.6.32'
 
 gradlePlugin {
     website = 'https://github.com/kelloggm/checkerframework-gradle-plugin/blob/master/README.md'

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -287,18 +287,15 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
 
       JavaVersion jvmVersion = JavaVersion.current();
 
-      // toolchains are an incubating feature of Gradle as of 6.8.3: https://docs.gradle.org/current/userguide/toolchains.html
-      def javaExtension = project.extensions.findByName("java")
-      if (javaExtension != null && javaExtension.hasProperty("toolchain")) {
-        def toolchain = javaExtension.toolchain
-        if (toolchain != null && toolchain.isConfigured()) {
-          def toolchainVersion = toolchain.getLanguageVersion().get()
-          def toolchainVersionInt = Integer.parseInt(toolchainVersion.toString())
-          if (toolchainVersionInt < 8) {
-            throw new IllegalStateException("The Checker Framework does not support Java versions before 8.")
-          } else {
-            jvmVersion = JavaVersion.toVersion(toolchainVersionInt)
-          }
+      // https://docs.gradle.org/current/userguide/toolchains.html
+      def toolchain = project.java?.toolchain
+      if (toolchain != null && toolchain.isConfigured()) {
+        def toolchainVersion = toolchain.getLanguageVersion().get()
+        def toolchainVersionInt = Integer.parseInt(toolchainVersion.toString())
+        if (toolchainVersionInt < 8) {
+          throw new IllegalStateException("The Checker Framework does not support Java versions before 8.")
+        } else {
+          jvmVersion = JavaVersion.toVersion(toolchainVersionInt)
         }
       }
 


### PR DESCRIPTION
The user reporting #256 provided the following build scan to show that #257, while it did resolve one deprecation warning, did not resolve all of them: https://scans.gradle.com/s/tcqljevj2apk4

This PR should hopefully fix the deprecation warning from that build scan. I haven't been able to reproduce this deprecation warning myself, so we'll need to wait for the user to confirm. I have tested that this doesn't seem to break existing compatibility with toolchains on a simple example.