### PR TITLE
Adding Kotlin DSL syntax for using locally-built Checker Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ if (project.hasProperty("cfLocal")) {
 }
 ```
 
+The same example, using Kotlin syntax in a `build.gradle.kts` file:
+
+```kotlin
+if (project.hasProperty("cfLocal")) {
+  val cfHome = System.getenv("CHECKERFRAMEWORK")
+  dependencies {
+    compileOnly(files(cfHome + "/checker/dist/checker-qual.jar"))
+    testCompileOnly(files(cfHome + "/checker/dist/checker-qual.jar"))
+    checkerFramework(files(cfHome + "/checker/dist/checker.jar"))
+  }
+}
+```
+
 ### Incremental compilation
 
 By default, the plugin assumes that all checkers are "isolating incremental annotation processors"


### PR DESCRIPTION
Modifications are needed to the standard Groovy syntax in order to use a locally-built Checker Framework in a project with a `build.gradle.kts` file.

This documents those modifications.