### PR TITLE
Support eisop fork without warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.40'
+    id 'org.checkerframework' version '0.6.41'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.40 of this plugin uses Checker Framework version 3.44.0 by default.
+Version 0.6.41 of this plugin uses Checker Framework version 3.44.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -258,7 +258,7 @@ top-level project is a Java project).  For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.40' apply false
+  id 'org.checkerframework' version '0.6.41' apply false
 }
 
 subprojects { subproject ->
@@ -299,7 +299,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.40' apply false
+  id 'org.checkerframework' version '0.6.41' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.40'
+version '0.6.41'
 
 gradlePlugin {
     website = 'https://github.com/kelloggm/checkerframework-gradle-plugin/blob/master/README.md'

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -311,9 +311,9 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
       def versionString
       try {
         def actualCFDependencySet = project.configurations.checkerFramework.getAllDependencies()
-                .matching({ dep ->
-                  dep.getName().equals("checker") && dep.getGroup().equals("org.checkerframework")
-                })
+                // Only check the name of the dependency, to support forks of the CF that
+                // use the same version scheme, such as the EISOP fork.
+                .matching({ dep -> dep.getName().equals("checker")})
         if (actualCFDependencySet.size() == 0) {
           if (userConfig.skipVersionCheck) {
             versionString = LIBRARY_VERSION

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CheckerFrameworkPlugin.groovy
@@ -311,8 +311,8 @@ final class CheckerFrameworkPlugin implements Plugin<Project> {
       def versionString
       try {
         def actualCFDependencySet = project.configurations.checkerFramework.getAllDependencies()
-                // Only check the name of the dependency, to support forks of the CF that
-                // use the same version scheme, such as the EISOP fork.
+                // Only check the name of the dependency (not the group), to support forks
+                // of the CF that use the same version scheme, such as the EISOP fork.
                 .matching({ dep -> dep.getName().equals("checker")})
         if (actualCFDependencySet.size() == 0) {
           if (userConfig.skipVersionCheck) {


### PR DESCRIPTION
Correctly handles version-checking for any Checker Framework fork whose version string starts with a version string from the main Checker Framework repository.

I tested that with the instructions in #277 this no longer leads to a printout about using the default Checker Framework version when using the EISOP fork. So, this closes out #275 completely.