### PR TITLE
Fix EISOP instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ ext {
 dependencies {
     compileOnly "io.github.eisop:checker-qual:${versions.eisopVersion}"
     testCompileOnly "io.github.eisop:checker-qual:${versions.eisopVersion}"
+    checkerFramework "io.github.eisop:checker-qual:${versions.eisopVersion}"
     checkerFramework "io.github.eisop:checker:${versions.eisopVersion}"
 }
 ```


### PR DESCRIPTION
When updating from the CF gradle plugin version 0.6.45 to 0.6.46 the described build instructions stopped working.
I didn't see a change in the plugin that caused this, so the breakage is rather mysterious to me.
Adding an explicit dependency on `checker-qual` seems to fix the problem.

See https://github.com/eisop/checker-framework/issues/1003.