### PR TITLE
Don't use the `project` at task execution time; instead, treat the build directory as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.49'
+    id 'org.checkerframework' version '0.6.50'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.49 of this plugin uses Checker Framework version 3.49.0 by default.
+Version 0.6.50 of this plugin uses Checker Framework version 3.49.0 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -258,7 +258,7 @@ top-level project is a Java project).  For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.49' apply false
+  id 'org.checkerframework' version '0.6.50' apply false
 }
 
 subprojects { subproject ->
@@ -299,7 +299,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.49' apply false
+  id 'org.checkerframework' version '0.6.50' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.49'
+version '0.6.50'
 
 gradlePlugin {
     website = 'https://github.com/kelloggm/checkerframework-gradle-plugin/blob/master/README.md'

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
@@ -1,7 +1,10 @@
 package org.checkerframework.gradle.plugin
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -26,13 +29,17 @@ class CreateManifestTask extends DefaultTask {
     @Input
     boolean incrementalize = true
 
+    @Input
+    final String buildDirLocation = project.layout.getBuildDirectory().toString()
+
     /**
      * Creates a manifest file listing all the checkers to run.
      */
     @TaskAction
     def generateManifest() {
-        def manifestDir = project.mkdir "${project.buildDir}/${manifestDirectoryName}"
-        def manifestFile = project.file("${manifestDir.absolutePath}/${manifestFileName}")
+        def manifestDir = new File(buildDirLocation + File.separator + "${manifestDirectoryName}")
+        manifestDir.mkdirs()
+        def manifestFile = new File("${manifestDir.absolutePath}" + File.separator + "${manifestFileName}")
         if (!manifestFile.createNewFile()) {
             manifestFile.delete()
             manifestFile.createNewFile()
@@ -40,8 +47,10 @@ class CreateManifestTask extends DefaultTask {
         manifestFile << this.checkers.join('\n')
 
         if (incrementalize) {
-            def gradleManifestDir = project.mkdir "${project.buildDir}/${gradleManifestDirectoryName}"
-            def gradleManifestFile = project.file("${gradleManifestDir.absolutePath}/${gradleManifestFileName}")
+            def gradleManifestDir = new File(buildDirLocation + File.separator + "${gradleManifestDirectoryName}")
+            gradleManifestDir.mkdirs()
+            def gradleManifestFile =
+                    new File("${gradleManifestDir.absolutePath}" + File.separator + "${gradleManifestFileName}")
             if (!gradleManifestFile.createNewFile()) {
                 gradleManifestFile.delete()
                 gradleManifestFile.createNewFile()
@@ -70,7 +79,7 @@ class CreateManifestTask extends DefaultTask {
      */
     @OutputFile
     def getManifestLocation() {
-        return "${project.buildDir}/${manifestDirectoryName}/${manifestFileName}"
+        return "${buildDirLocation}" + File.separator + "${manifestDirectoryName}" + File.separator + "${manifestFileName}"
     }
 
     /**
@@ -79,6 +88,6 @@ class CreateManifestTask extends DefaultTask {
      */
     @OutputFile
     def getGradleManifestLocation() {
-        return "${project.buildDir}/${gradleManifestDirectoryName}/${gradleManifestFileName}"
+        return "${buildDirLocation}" + File.separator + "${gradleManifestDirectoryName}" + File.separator + "${gradleManifestFileName}"
     }
 }

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
@@ -1,10 +1,7 @@
 package org.checkerframework.gradle.plugin
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 


### PR DESCRIPTION
Fixes #294 

