### PR TITLE
Treat the build directory as an optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `build.gradle` file:
 ```groovy
 plugins {
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.51'
+    id 'org.checkerframework' version '0.6.52'
 }
 
 apply plugin: 'org.checkerframework'
@@ -94,7 +94,7 @@ the definitions of the custom qualifiers.
 
 ### Specifying a Checker Framework version
 
-Version 0.6.51 of this plugin uses Checker Framework version 3.49.1 by default.
+Version 0.6.52 of this plugin uses Checker Framework version 3.49.1 by default.
 Anytime you upgrade to a newer version of this plugin,
 it might use a different version of the Checker Framework.
 
@@ -259,7 +259,7 @@ top-level project is a Java project).  For example:
 
 ```groovy
 plugins {
-  id 'org.checkerframework' version '0.6.51' apply false
+  id 'org.checkerframework' version '0.6.52' apply false
 }
 
 subprojects { subproject ->
@@ -300,7 +300,7 @@ plugins {
   id "net.ltgt.errorprone" version "1.1.1" apply false
   // To do Checker Framework pluggable type-checking (and disable Error Prone), run:
   // ./gradlew compileJava -PuseCheckerFramework=true
-  id 'org.checkerframework' version '0.6.51' apply false
+  id 'org.checkerframework' version '0.6.52' apply false
 }
 
 if (!project.hasProperty("useCheckerFramework")) {

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group 'org.checkerframework'
-version '0.6.51'
+version '0.6.52'
 
 gradlePlugin {
     website = 'https://github.com/kelloggm/checkerframework-gradle-plugin/blob/master/README.md'

--- a/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
+++ b/src/main/groovy/org/checkerframework/gradle/plugin/CreateManifestTask.groovy
@@ -27,7 +27,7 @@ class CreateManifestTask extends DefaultTask {
     boolean incrementalize = true
 
     @Input
-    final String buildDirLocation = project.layout.getBuildDirectory().toString()
+    final String buildDirLocation = project.layout.getBuildDirectory().get().toString()
 
     /**
      * Creates a manifest file listing all the checkers to run.


### PR DESCRIPTION
Fixes the failed build of https://github.com/plume-lib/options/pull/442 for me when testing locally. @mernst can you confirm that this is fixing the issues that you are seeing?

The problem was that #295 assumed that the build directory could be directly converted to a string. This is true _sometimes_ (I do not understand Gradle well enough to tell you when), but not always - sometimes there is a wrapper around it. Calling `get()` first removes the wrapper and allows the plugin to get the build directory location as a string, which is what we wanted. I tested this with both `options` and with the local test I created for #295 based on @Calvin-L's report in #294, and it works in both setups. But, I don't have much confidence that this is really the "right" fix.